### PR TITLE
Improve the performance of KnuthSolver by x50

### DIFF
--- a/src/main/kotlin/net/danlew/wordle/algorithm/KnuthSolver.kt
+++ b/src/main/kotlin/net/danlew/wordle/algorithm/KnuthSolver.kt
@@ -36,11 +36,11 @@ class KnuthSolver(
 
     val guessRankings = wordPool.map { guess ->
       var score = Int.MAX_VALUE
-      val noGuessDupes = guess.hasNoDuplicateCharacters()
+      val hitCounts = mutableMapOf<GuessResult, Int>().withDefault { 0 }
       for (possibleTarget in possibleTargets) {
         val guessResult = GuessResult(guess, evaluateGuess(guess, possibleTarget))
-        val numResults = possibleTargets.count { guessResult.couldMatch(it, noGuessDupes) }
-        score = minOf(score, targetSize - numResults)
+        hitCounts[guessResult] = hitCounts.getValue(guessResult) + 1
+        score = minOf(score, targetSize - hitCounts.getValue(guessResult))
       }
       return@map GuessScore(guess, score)
     }.sortedByDescending { it.score }
@@ -51,8 +51,6 @@ class KnuthSolver(
     val guesses = guessRankings.takeWhile { it.score == maxScore }
     return (guesses.find { it.guess in possibleTargets } ?: guesses.first()).guess
   }
-
-  private fun String.hasNoDuplicateCharacters() = chars().distinct().count().toInt() == length
 
   private data class GuessScore(val guess: String, val score: Int)
 


### PR DESCRIPTION
According to a [Wikipedia article](https://en.wikipedia.org/wiki/Mastermind_(board_game)#Worst_case:_Five-guess_algorithm), I believe we can count the number of possible targets generating the same hint for a guess to compute the score of the guess instead.  The change produces the same histogram so I believe this does not change the behaviour.

The code might not be idiomatic from Kotlin point of view.  Feel free to add any modifications to it.  Thanks!

#### Bench mark environment
Ubuntu 20.04 (Core i7-8700 3.2GHz x6)

#### Result (before)
```
Computing KnuthSolver Histogram... (could take a while)!
Solved in 1 guess(es): 1
Solved in 2 guess(es): 53
Solved in 3 guess(es): 990
Solved in 4 guess(es): 1162
Solved in 5 guess(es): 107
Solved in 6 guess(es): 2
Failed to solve: 0
Average # guesses: 3.5732181425485963
Completed in 3446 second(s)!

Computing KnuthSolver Histogram (hard mode)... (could take a while)!
Solved in 1 guess(es): 1
Solved in 2 guess(es): 89
Solved in 3 guess(es): 907
Solved in 4 guess(es): 1054
Solved in 5 guess(es): 209
Solved in 6 guess(es): 40
Failed to solve: 15
Average # guesses: 3.652608695652174
Completed in 1777 second(s)!
```

#### Result (after)
```
Computing KnuthSolver Histogram... (could take a while)!
Solved in 1 guess(es): 1
Solved in 2 guess(es): 53
Solved in 3 guess(es): 990
Solved in 4 guess(es): 1162
Solved in 5 guess(es): 107
Solved in 6 guess(es): 2
Failed to solve: 0
Average # guesses: 3.5732181425485963
Completed in 90 second(s)!

Computing KnuthSolver Histogram (hard mode)... (could take a while)!
Solved in 1 guess(es): 1
Solved in 2 guess(es): 89
Solved in 3 guess(es): 907
Solved in 4 guess(es): 1054
Solved in 5 guess(es): 209
Solved in 6 guess(es): 40
Failed to solve: 15
Average # guesses: 3.652608695652174
Completed in 36 second(s)!
```